### PR TITLE
Add user-configurable gain

### DIFF
--- a/app/src/main/cpp/FullDuplexPassthru.h
+++ b/app/src/main/cpp/FullDuplexPassthru.h
@@ -84,9 +84,11 @@ public:
         if (bytesFromInput > 0 && mGain != 1.0) {
             // Apply gain in-place to inputData.
             // Assumes we're dealing with int16 samples.
-            void* inputDataEnd = (void*)((u_char *)inputData + bytesFromInput);
-            for (int16_t* sample = (int16_t*)inputData; sample < inputDataEnd; sample++) {
-                applyGain(sample, mGain);
+            if (this->getInputStream()->getFormat() == oboe::AudioFormat::I16) {
+                void *inputDataEnd = (void *) ((u_char *) inputData + bytesFromInput);
+                for (int16_t *sample = (int16_t *) inputData; sample < inputDataEnd; sample++) {
+                    applyGain(sample, mGain);
+                }
             }
         }
 

--- a/app/src/main/cpp/NativeAudioEngine.cpp
+++ b/app/src/main/cpp/NativeAudioEngine.cpp
@@ -142,6 +142,11 @@ const char * NativeAudioEngine::getOboeVersion() {
     return oboe::Version::Text;
 }
 
+void NativeAudioEngine::setGainDecibels(double decibels) {
+    LOGD("Gain set to %+.1fdB", decibels);
+    mFullDuplexPassthru.setGainDecibels(decibels);
+}
+
 bool NativeAudioEngine::prepareRecording(JNIEnv *env) {
     LOGD("prepareRecording");
     if (mIsRecording) {

--- a/app/src/main/cpp/NativeAudioEngine.h
+++ b/app/src/main/cpp/NativeAudioEngine.h
@@ -59,7 +59,9 @@ class NativeAudioEngine : public oboe::AudioStreamCallback {
     int32_t getAudioApi();
     const char * getOboeVersion();
 
-   private:
+    void setGainDecibels(double decibels);
+
+private:
     JavaVM* mJavaVm;
     FullDuplexPassthru mFullDuplexPassthru;
     jobject mCallbackObject;

--- a/app/src/main/cpp/jni_bridge.cpp
+++ b/app/src/main/cpp/jni_bridge.cpp
@@ -222,4 +222,16 @@ extern "C" {
         }
         return env->NewStringUTF(engine->getOboeVersion());
     }
+
+    JNIEXPORT void JNICALL
+    Java_tech_schober_vinylcast_audio_NativeAudioEngine_setGainDecibels(JNIEnv *env, jclass clazz,
+                                                                        jdouble decibels) {
+        if (engine == nullptr) {
+            LOGE(
+                    "Engine is null, you must call createEngine "
+                    "before calling this method");
+            return;
+        }
+        engine->setGainDecibels(decibels);
+    }
 }

--- a/app/src/main/java/tech/schober/vinylcast/VinylCastService.java
+++ b/app/src/main/java/tech/schober/vinylcast/VinylCastService.java
@@ -42,6 +42,7 @@ import tech.schober.vinylcast.audio.AudioRecordStreamProvider;
 import tech.schober.vinylcast.audio.AudioStreamProvider;
 import tech.schober.vinylcast.audio.AudioVisualizer;
 import tech.schober.vinylcast.audio.ConvertAudioStreamProvider;
+import tech.schober.vinylcast.audio.NativeAudioEngine;
 import tech.schober.vinylcast.server.HttpStreamServer;
 import tech.schober.vinylcast.server.HttpStreamServerImpl;
 import tech.schober.vinylcast.utils.VinylCastHelpers;
@@ -260,6 +261,9 @@ public class VinylCastService extends MediaBrowserServiceCompat {
         int playbackDeviceId = VinylCastHelpers.getSharedPreferenceStringAsInteger(this, R.string.prefs_key_local_playback_device_id, R.string.prefs_default_local_playback_device_id);
         @AudioStreamProvider.AudioEncoding int audioEncoding = VinylCastHelpers.getSharedPreferenceStringAsInteger(this, R.string.prefs_key_audio_encoding, R.string.prefs_default_audio_encoding);
         boolean lowLatency = PreferenceManager.getDefaultSharedPreferences (this).getBoolean(getString(R.string.prefs_key_low_latency), Boolean.valueOf(getString(R.string.prefs_default_low_latency)));
+        double gainDecibels = VinylCastHelpers.getGainPreference(this);
+
+        NativeAudioEngine.setGainDecibels(gainDecibels);
 
         if (isPlaybackDeviceSelected() && !requestAudioFocus()) {
             Timber.e("Failed to get Audio Focus for playback. Stopping VinylCastService...");

--- a/app/src/main/java/tech/schober/vinylcast/audio/NativeAudioEngine.java
+++ b/app/src/main/java/tech/schober/vinylcast/audio/NativeAudioEngine.java
@@ -17,6 +17,7 @@ public enum NativeAudioEngine {
     public static native void setPlaybackDeviceId(int deviceId);
     public static native boolean setAudioApi(int apiType);
     public static native boolean setLowLatency(boolean lowLatency);
+    public static native void setGainDecibels(double decibels);
     public static native void setAudioDataListener(NativeAudioEngineListener listener);
     public static native int getSampleRate();
     public static native int getChannelCount();

--- a/app/src/main/java/tech/schober/vinylcast/ui/settings/SettingsFragment.java
+++ b/app/src/main/java/tech/schober/vinylcast/ui/settings/SettingsFragment.java
@@ -108,7 +108,7 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Servic
 
     private void updateGainSummary(SeekBarPreference preference, int newValue) {
         double gain = VinylCastHelpers.convertGainPrefToDecibels(newValue);
-        String summary = String.format("Gain: %+.1fdB", gain);
+        String summary = getString(R.string.prefs_summary_gain, gain);
         preference.setSummary(summary);
     }
 
@@ -150,7 +150,7 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Servic
         AudioDevicePreference playbackDevicePref = findPreference(R.string.prefs_key_local_playback_device_id);
         CheckBoxPreference lowLatencyPref = findPreference(R.string.prefs_key_low_latency);
         ListPreference audioEncodingPref = findPreference(R.string.prefs_key_audio_encoding);
-        SeekBarPreference gainPref = findPreference("gain");
+        SeekBarPreference gainPref = findPreference(R.string.prefs_key_gain);
         Preference feedbackPref = findPreference(R.string.prefs_key_feedback);
         Preference androidApiLevelPref = findPreference(R.string.prefs_key_android_api_level);
         Preference appVersionPref = findPreference(R.string.prefs_key_app_version);

--- a/app/src/main/java/tech/schober/vinylcast/utils/VinylCastHelpers.java
+++ b/app/src/main/java/tech/schober/vinylcast/utils/VinylCastHelpers.java
@@ -115,6 +115,17 @@ public class VinylCastHelpers {
         return Integer.valueOf(PreferenceManager.getDefaultSharedPreferences(context).getString(context.getString(prefsKeyResId), context.getString(prefsDefaultResId)));
     }
 
+    public static double convertGainPrefToDecibels(int intGain) {
+        // Convert from an int with a range of 0-200 to a double with range -10.0-10.0.
+        double decibels = (intGain - 100) / 10.0f;
+        return decibels;
+    }
+
+    public static double getGainPreference(Context context) {
+        int intGain = PreferenceManager.getDefaultSharedPreferences(context).getInt(context.getString(R.string.prefs_key_gain), 100);
+        return convertGainPrefToDecibels(intGain);
+    }
+
     /**
      * Get an OutputStream and InputStream that provides raw audio output.
      * @return Pair<OutputStream, InputStream>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -86,4 +86,8 @@
     <string name="prefs_default_summary_http_clients">-</string>
     <string name="prefs_default_summary_audio_api">-</string>
 
+    <string name="prefs_key_gain">gain</string>
+    <string name="prefs_title_gain">Gain</string>
+    <string name="prefs_summary_gain">Gain: ?.??dB</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -88,6 +88,6 @@
 
     <string name="prefs_key_gain">gain</string>
     <string name="prefs_title_gain">Gain</string>
-    <string name="prefs_summary_gain">Gain: ?.??dB</string>
+    <string name="prefs_summary_gain">Gain: %+.1fdB</string>
 
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto" >
+<PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android">
     <PreferenceCategory
         app:key="@string/prefs_key_category_audio_devices"
         app:title="@string/prefs_title_category_audio_devices"
@@ -39,6 +40,17 @@
             app:defaultValue="@string/prefs_default_audio_encoding"
             app:useSimpleSummaryProvider="true"
             app:iconSpaceReserved="false" />
+
+        <androidx.preference.SeekBarPreference
+            app:key="@string/prefs_key_gain"
+            app:title="@string/prefs_title_gain"
+            app:summary="@string/prefs_summary_gain"
+            app:iconSpaceReserved="false"
+            app:defaultValue="100"
+            app:showSeekBarValue="false"
+            app:updatesContinuously="true"
+            android:min="0"
+            android:max="200" />
 
         <Preference
             app:key="@string/prefs_key_http_server"


### PR DESCRIPTION
Having a gain setting in the Vinyl Cast app is handy for those of us with turntables with USB out, and no volume/gain controls on the turntable itself.

Replaces https://github.com/aschober/vinyl-cast/pull/27 because I had to force push.